### PR TITLE
Add SecPolicy suitable for validating TLS.

### DIFF
--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -26,6 +26,10 @@ pub type SecKeyRef = *mut OpaqueSecKeyRef;
 pub struct OpaqueSecIdentityRef(c_void);
 pub type SecIdentityRef = *mut OpaqueSecIdentityRef;
 
+#[repr(C)]
+pub struct OpaqueSecPolicyRef(c_void);
+pub type SecPolicyRef = *mut OpaqueSecPolicyRef;
+
 pub const errSecSuccess: OSStatus = 0;
 pub const errSecIO: OSStatus = -36;
 pub const errSecParam: OSStatus = -50;

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -15,5 +15,6 @@ pub mod item;
 pub mod key;
 pub mod keychain;
 pub mod keychain_item;
+pub mod policy;
 pub mod secure_transport;
 pub mod trust;

--- a/security-framework-sys/src/policy.rs
+++ b/security-framework-sys/src/policy.rs
@@ -1,0 +1,9 @@
+use core_foundation_sys::base::{Boolean, CFTypeID};
+use core_foundation_sys::string::CFStringRef;
+
+use base::SecPolicyRef;
+
+extern {
+    pub fn SecPolicyCreateSSL(server: Boolean, hostname: CFStringRef) -> SecPolicyRef;
+    pub fn SecPolicyGetTypeID() -> CFTypeID;
+}

--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -70,6 +70,7 @@ pub mod key;
 pub mod keychain;
 pub mod keychain_item;
 pub mod os;
+pub mod policy;
 pub mod secure_transport;
 pub mod trust;
 

--- a/security-framework/src/policy.rs
+++ b/security-framework/src/policy.rs
@@ -1,0 +1,52 @@
+//! Security Policies support.
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
+use security_framework_sys::base::{errSecParam, SecPolicyRef};
+use security_framework_sys::policy::*;
+
+use std::mem;
+use std::fmt;
+
+use ErrorNew;
+use base::{Error, Result};
+
+make_wrapper! {
+    /// A type representing a certificate validation policy.
+    struct SecPolicy, SecPolicyRef, SecPolicyGetTypeID
+}
+
+unsafe impl Sync for SecPolicy {}
+unsafe impl Send for SecPolicy {}
+
+impl fmt::Debug for SecPolicy {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("SecPolicy")
+           .finish()
+    }
+}
+
+impl SecPolicy {
+    /// Creates a `SecPolicy` suitable for validating certificates for SSL.
+    pub fn for_ssl(server: bool, hostname: &str) -> Result<SecPolicy> {
+        let hostname_cf = CFString::new(hostname);
+        unsafe {
+            let policy = SecPolicyCreateSSL(server as u8, hostname_cf.as_concrete_TypeRef());
+            if policy.is_null() {
+                Err(Error::new(errSecParam))
+            } else {
+                Ok(SecPolicy::wrap_under_create_rule(policy))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ::policy::SecPolicy;
+
+    #[test]
+    fn for_ssl() {
+        let policy = SecPolicy::for_ssl(true, "certifi.org");
+        assert_eq!(policy.is_ok(), true);
+    }
+}


### PR DESCRIPTION
I'm looking at writing a tool that allows validation of certificate chains using the appropriate binary available on the system. As a first pass, I want to try this on OS X, which involves making some function calls and types that aren't yet exposed in this library.

The first of those is the SecPolicy and SecPolicyRef. In this case, for my limited use-case, all I need is the `SecPolicyCreateSSL()` call, so that's all I've exposed here: essentially an opaque struct that can be created but then has almost nothing done with it. Admittedly quite boring, but turns out to be all we need.

Coming down the line I may add one or two other methods, but otherwise this is pretty complete.

Let me know if you need anything extra from me as part of this work!