### PR TITLE
discard import-export from s-f on ios

### DIFF
--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -63,6 +63,7 @@ pub mod base;
 pub mod certificate;
 pub mod cipher_suite;
 pub mod identity;
+#[cfg(target_os = "macos")]
 pub mod import_export;
 pub mod item;
 pub mod key;


### PR DESCRIPTION
import-export module is skipped in -sys crate, it should be discarded too from the "rusty" crate to build on ios.

As far as I can tell, without this change, current top of tree does not crosscompile to ios.