### PR TITLE
Allow calling functions that may not exist

### DIFF
--- a/security-framework/src/secure_transport/ffi.rs
+++ b/security-framework/src/secure_transport/ffi.rs
@@ -1,0 +1,59 @@
+#![allow(bad_style)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use core_foundation_sys::base::*;
+use security_framework_sys::base::*;
+pub use security_framework_sys::secure_transport::*;
+
+use std::mem;
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use libc;
+
+unsafe fn get<'a, T>(ptr: &'a AtomicUsize, name: &str) -> Option<&'a T> {
+    assert_eq!(mem::size_of::<T>(), mem::size_of_val(ptr));
+    match ptr.load(Ordering::SeqCst) {
+        0 => {}
+        1 => return None,
+        _ => return Some(&*(ptr as *const _ as *const T)),
+    }
+
+    let lib = "Security.framework/Versions/A/Security\0";
+    let lib = libc::dlopen(lib.as_ptr() as *const _, libc::RTLD_LAZY);
+    let mut ret = 1;
+    if !lib.is_null() {
+        let sym = libc::dlsym(lib, name.as_ptr() as *const _);
+        if !sym.is_null() {
+            ret = sym as usize;
+        }
+    }
+    match ptr.compare_exchange(0, ret, Ordering::SeqCst, Ordering::SeqCst) {
+        Ok(1) |
+        Err(1) => None,
+        Ok(_) |
+        Err(_) => Some(&*(ptr as *const _ as *const T)),
+    }
+}
+
+macro_rules! compat {
+    ($(fn $name:ident($($arg:ident: $t:ty),*) -> $ret:ty {
+        $($code:tt)*
+    })*) => {$(
+        pub unsafe extern fn $name($($arg:$t),*) -> $ret {
+            static PTR: AtomicUsize = ATOMIC_USIZE_INIT;
+            type T = unsafe extern fn($($t),*) -> $ret;
+            match get::<T>(&PTR, concat!(stringify!($name), "\0")) {
+                Some(f) => f($($arg),*),
+                None => { $($code)* }
+            }
+        }
+    )*}
+}
+
+#[cfg(not(feature = "OSX_10_8"))]
+compat! {
+    fn SSLSetProtocolVersionMin(context: SSLContextRef,
+                                minVersion: SSLProtocol) -> OSStatus {
+        errSecIO
+    }
+}

--- a/security-framework/src/secure_transport/mod.rs
+++ b/security-framework/src/secure_transport/mod.rs
@@ -81,7 +81,6 @@ use core_foundation_sys::base::OSStatus;
 use core_foundation_sys::base::{kCFAllocatorDefault, CFRelease};
 use security_framework_sys::base::{errSecSuccess, errSecIO, errSecBadReq, errSecTrustSettingDeny,
                                    errSecNotTrusted};
-use security_framework_sys::secure_transport::*;
 use std::any::Any;
 use std::io;
 use std::io::prelude::*;
@@ -99,6 +98,9 @@ use certificate::SecCertificate;
 use cipher_suite::CipherSuite;
 use identity::SecIdentity;
 use trust::{SecTrust, TrustResult};
+
+mod ffi;
+use self::ffi::*;
 
 /// Specifies a side of a TLS session.
 #[derive(Debug, Copy, Clone)]
@@ -273,7 +275,6 @@ macro_rules! ssl_protocol {
                 }
             }
 
-            #[cfg(feature = "OSX_10_8")]
             fn to_raw(&self) -> SSLProtocol {
                 use self::SslProtocol::*;
 
@@ -631,8 +632,8 @@ impl SslContext {
 
     /// Sets the minimum protocol version allowed by the session.
     ///
-    /// Requires the `OSX_10_8` (or greater) feature.
-    #[cfg(feature = "OSX_10_8")]
+    /// Note that this function may fail if the `OSX_10_8` (or greater) feature
+    /// is not enabled and it's called on OSX 10.7 or before.
     pub fn set_protocol_version_min(&mut self, min_version: SslProtocol) -> Result<()> {
         unsafe { cvt(SSLSetProtocolVersionMin(self.0, min_version.to_raw())) }
     }


### PR DESCRIPTION
This crate uses Cargo features to define the API, gating access to APIs
which weren't enabled. This isn't necessarily always the desired use
case, however. Sometimes a binary wants to be compiled as maximally
flexible (e.g runs almost anywhere) but still call newer APIs where it
can.

To accommodate this use case, this commit implements a fallback for APIs
where features are not enabled. Currently this is just a
proof-of-concept for one function to gauge interest, but the theory is
that this could generally apply to many APIs to provide a uniform API
for this crate across all OS versions.

Technically speaking, this enables a feature where when an FFI function
wouldn't otherwise be defined we define our own. Our own wrapper then
looks up the symbol at runtime (via `dlopen` + `dlsym`) and caches the
result in a global. The wrapper then also provides a fallback
implementation which typically just returns an error. This is similar to
what's done in the standard library as well.