### PR TITLE
Add ability to search for items by label

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -20,6 +20,7 @@ extern "C" {
     pub static kSecMatchSearchList: CFStringRef;
 
     pub static kSecAttrKeyType: CFStringRef;
+    pub static kSecAttrLabel: CFStringRef;
 
     #[cfg(target_os = "macos")]
     pub static kSecAttrKeyTypeRSA: CFStringRef;

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -56,6 +56,7 @@ pub struct ItemSearchOptions {
     class: Option<ItemClass>,
     load_refs: bool,
     limit: Option<i64>,
+    label: Option<CFString>,
 }
 
 #[cfg(target_os = "macos")]
@@ -102,6 +103,12 @@ impl ItemSearchOptions {
         self
     }
 
+    /// Search for an item with the given label.
+    pub fn label(&mut self, label: &str) -> &mut ItemSearchOptions {
+        self.label = Some(CFString::new(label));
+        self
+    }
+
     /// Search for objects.
     pub fn search(&self) -> Result<Vec<SearchResult>> {
         unsafe {
@@ -124,6 +131,11 @@ impl ItemSearchOptions {
             if let Some(limit) = self.limit {
                 params.push((CFString::wrap_under_get_rule(kSecMatchLimit),
                              CFNumber::from_i64(limit).as_CFType()));
+            }
+
+            if let Some(ref label) = self.label {
+                params.push((CFString::wrap_under_get_rule(kSecAttrLabel),
+                             label.as_CFType()));
             }
 
             let params = CFDictionary::from_CFType_pairs(&params);


### PR DESCRIPTION
This is useful if we know the label of the thing we're searching for already.  I tested this with the following example:

```rust
extern crate security_framework;

use security_framework::item::{ItemSearchOptions, ItemClass};

pub fn main() {
    let results = ItemSearchOptions::new()
        .class(ItemClass::Identity)
        .label("adunham")
        .search()
        .unwrap();

    println!("results = {:?}", results);
}
```

This shows the expected output:

```
results = [SearchResult { reference: Some(Identity(SecIdentity { certificate: SecCertificate { subject: "adunham" }, private_key: SecKey })) }]
```