### PR TITLE
SSLSetProtocolVersionEnabled is macos only

### DIFF
--- a/security-framework-sys/src/secure_transport.rs
+++ b/security-framework-sys/src/secure_transport.rs
@@ -252,6 +252,7 @@ extern "C" {
     pub fn SSLSetProtocolVersionMax(context: SSLContextRef, maxVersion: SSLProtocol) -> OSStatus;
     #[cfg(any(feature = "OSX_10_8", target_os = "ios"))]
     pub fn SSLSetProtocolVersionMin(context: SSLContextRef, minVersion: SSLProtocol) -> OSStatus;
+    #[cfg(target_os = "macos")]
     pub fn SSLSetProtocolVersionEnabled(context: SSLContextRef,
                                         protocol: SSLProtocol,
                                         enable: Boolean) -> OSStatus;

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -631,6 +631,7 @@ impl SslContext {
     /// `set_protocol_version_max` and `set_protocol_version_min`, although if
     /// you're working with OSX 10.8 or before you may have to use this API
     /// instead.
+    #[cfg(target_os = "macos")]
     pub fn set_protocol_version_enabled(&mut self,
                                         protocol: SslProtocol,
                                         enabled: bool) -> Result<()> {


### PR DESCRIPTION
It may impact whatever @alexcrichton  in sfackler/rust-security-framework#16 was trying to achieve.