### PR TITLE
make SslAuthenticate enum Copy+Clone

### DIFF
--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -322,7 +322,7 @@ impl SessionState {
 }
 
 /// Specifies a server's requirement for client certificates.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum SslAuthenticate {
     /// Do not request a client certificate.
     Never,


### PR DESCRIPTION
This is a simple enum, and will make functions that take this as a parameter easier to use.

Also, it looks like the same treatment could/should be done to SslClientCertificateState, but I haven't run into needing that.