### PR TITLE
Unconditionally define protocol versions

### DIFF
--- a/security-framework-sys/src/secure_transport.rs
+++ b/security-framework-sys/src/secure_transport.rs
@@ -16,11 +16,8 @@ pub type SSLProtocol = c_int;
 pub const kSSLProtocolUnknown: SSLProtocol = 0;
 pub const kSSLProtocol3: SSLProtocol = 2;
 pub const kTLSProtocol1: SSLProtocol = 4;
-#[cfg(any(feature = "OSX_10_8", target_os = "ios"))]
 pub const kTLSProtocol11: SSLProtocol = 7;
-#[cfg(any(feature = "OSX_10_8", target_os = "ios"))]
 pub const kTLSProtocol12: SSLProtocol = 8;
-#[cfg(any(feature = "OSX_10_8", target_os = "ios"))]
 pub const kDTLSProtocol1: SSLProtocol = 9;
 pub const kSSLProtocol2: SSLProtocol = 1;
 pub const kSSLProtocol3Only: SSLProtocol = 3;

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -388,18 +388,15 @@ ssl_protocol! {
     /// if the peer does not support TLS 1.1.
     ///
     /// Requires the `OSX_10_8` (or greater) feature.
-    #[cfg(feature = "OSX_10_8")]
     const Tls11 = kTLSProtocol11,
     /// The TLS 1.2 protocol is preferred, though lower versions may be used
     /// if the peer does not support TLS 1.2.
     ///
     /// Requires the `OSX_10_8` (or greater) feature.
-    #[cfg(feature = "OSX_10_8")]
     const Tls12 = kTLSProtocol12,
     /// Only the SSL 2.0 protocol is accepted.
     const Ssl2 = kSSLProtocol2,
     /// The DTLSv1 protocol is preferred.
-    #[cfg(feature = "OSX_10_8")]
     const Dtls1 = kDTLSProtocol1,
     /// Only the SSL 3.0 protocol is accepted.
     const Ssl3Only = kSSLProtocol3Only,


### PR DESCRIPTION
Not having these can cause panics in negotiated_protocol_version()
if run on a system newer than security-framework was configured
for.