### PR TITLE
Enable specification of certain cipher suites

### DIFF
--- a/security-framework/src/cipher_suite.rs
+++ b/security-framework/src/cipher_suite.rs
@@ -7,7 +7,7 @@ macro_rules! make_suites {
     ($($suite:ident),+) => {
         /// Specifies cipher suites
         #[allow(non_camel_case_types, missing_docs)]
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum CipherSuite {
             $($suite),+
         }

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -1428,6 +1428,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(target_os = "ios", ignore)] // FIXME same issue as cipher_configuration
     fn test_builder_blacklist_ciphers() {
         let stream = p!(TcpStream::connect("google.com:443"));
 


### PR DESCRIPTION
This enables implementation of https://github.com/sfackler/rust-native-tls/issues/4 for Mac.

Instead of just a `supported_ciphers` call, I decided to enable both whitelist/blacklist so the API allows people to disable (i.e. blacklist) very insecure cipher suites without needing to list every other suite.

On the rust-native-tls layer, we'll maintain a mapping from the `Algorithm` to a Vector of CipherSuite that corresponds to that Algorithm.