### PR TITLE
Handle missing 'items' from pkcs12 file more gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you shall be dual licensed as above, without any
 additional terms or conditions.
+

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-framework"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Security Framework bindings"

--- a/security-framework/src/import_export.rs
+++ b/security-framework/src/import_export.rs
@@ -117,7 +117,7 @@ impl Pkcs12ImportOptions {
                 let label =
                     raw_item
                         .find(kSecImportItemLabel as *const _)
-                        .map_or(String::new(""), |label| {
+                        .map_or(String::new(), |label| {
                             CFString::wrap_under_get_rule(label as *const _).to_string()
                         });
                 let key_id =


### PR DESCRIPTION
This will either use a default when possible, or will give a more useful error message should particular 'items' be missing from pkcs12 file.

See #36 