### PR TITLE
upgrade core-foundation dep version

### DIFF
--- a/security-framework-sys/Cargo.toml
+++ b/security-framework-sys/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-core-foundation-sys = "0.2.1"
+core-foundation-sys = "0.4"
 
 [features]
 OSX_10_8 = []

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["test/*"]
 
 [dependencies]
 security-framework-sys = { version = "0.1.15", path = "../security-framework-sys" }
-core-foundation = "0.2.1"
-core-foundation-sys = "0.2.1"
+core-foundation = "0.4"
+core-foundation-sys = "0.4"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
I know you just cut a build yesterday.  Are you willing to cut another with just an upgrade in the dep version for `core-foundation`?  This will help me get rid of some duplicate deps in my project.

It's a clean update since core-foundation is very unlikely to have a breaking change :)

Thanks! 