### PR TITLE
Fix incorrect type in certificate_at_index()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ matrix:
       - osx_image: xcode7.3
         env: TARGET=x86_64-apple-ios
 
+      # 32-bit OS X 10.9
+      - osx_image: xcode6.2
+        env:
+          - FEATURES="OSX_10_9"
+          - TARGET=i686-apple-darwin
+
       # OS X 10.9
       - osx_image: xcode6.2
         env:

--- a/security-framework/src/trust.rs
+++ b/security-framework/src/trust.rs
@@ -119,7 +119,7 @@ impl SecTrust {
     /// Returns a specific certificate from the certificate chain used to evaluate trust.
     ///
     /// Note: evaluate must first be called on the SecTrust.
-    pub fn certificate_at_index(&self, ix: i64) -> Option<SecCertificate> {
+    pub fn certificate_at_index(&self, ix: CFIndex) -> Option<SecCertificate> {
         unsafe {
             let certificate = SecTrustGetCertificateAtIndex(self.0, ix);
             if certificate.is_null() {


### PR DESCRIPTION
Fixes #43
Also adds a single i686 travis build, so this type of thing can be caught in the future. (Also I don't have any way to test this besides travis)