### PR TITLE
Make io::ErrorKind::NotConnected not fatal

### DIFF
--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -842,6 +842,7 @@ fn translate_err(e: &io::Error) -> OSStatus {
         io::ErrorKind::NotFound => errSSLClosedGraceful,
         io::ErrorKind::ConnectionReset => errSSLClosedAbort,
         io::ErrorKind::WouldBlock => errSSLWouldBlock,
+        io::ErrorKind::NotConnected => errSSLWouldBlock,
         _ => errSecIO,
     }
 }


### PR DESCRIPTION
Trying to handshake with a yet unconnected Socket is not fatal,
This is symmetric to OpenSSL
```
fn retriable_error(err: &io::Error) -> bool {
    match err.kind() {
        io::ErrorKind::WouldBlock |
        io::ErrorKind::NotConnected => true,
        _ => false,
    }
}
```