### PR TITLE
Updating OS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Documentation](https://sfackler.github.io/rust-security-framework/doc/v0.2/security_framework)
 
-Bindings to OSX's Security Framework.
+Bindings to the macOS Security Framework.
 
 ## License
 


### PR DESCRIPTION
This change is a few OS releases old now, newer users won't search for OSX, or OS X, but might search for mac or macOS.