### PR TITLE
Improve Keychain Item SearchResult(s).

### DIFF
--- a/security-framework/src/os/macos/item.rs
+++ b/security-framework/src/os/macos/item.rs
@@ -84,8 +84,8 @@ mod test {
             .class(ItemClass::certificate())
             .search());
         assert_eq!(1, results.len());
-        let certificate = match results[0].reference {
-            Some(Reference::Certificate(ref cert)) => cert,
+        let certificate = match results[0] {
+            SearchResult::Ref(Reference::Certificate(ref cert)) => cert,
             _ => panic!("expected certificate"),
         };
         assert_eq!("foobar.com", p!(certificate.common_name()).to_string());

--- a/security-framework/src/os/macos/mod.rs
+++ b/security-framework/src/os/macos/mod.rs
@@ -21,7 +21,7 @@ pub mod test {
     use std::path::Path;
 
     use identity::SecIdentity;
-    use item::{ItemClass, ItemSearchOptions, Reference};
+    use item::{ItemClass, ItemSearchOptions, Reference, SearchResult};
     use os::macos::keychain::SecKeychain;
 
     pub fn identity(dir: &Path) -> SecIdentity {
@@ -31,8 +31,8 @@ pub mod test {
             .class(ItemClass::identity())
             .keychains(&[keychain])
             .search());
-        match items.pop().unwrap().reference {
-            Some(Reference::Identity(identity)) => identity,
+        match items.pop().unwrap() {
+            SearchResult::Ref(Reference::Identity(identity)) => identity,
             _ => panic!("expected identity"),
         }
     }


### PR DESCRIPTION
This PR is another take on generic password support for security-framework:
* ItemSearchOptions can now return item attributes and data (passwords for
internet and generic password item classes).
* SearchResult(s) are now an enum depending on the return kind of the
search. CFDict results can be simplified to a HashMap<String, String>.

This work in turn allows callers to retrieve passwords and associated data (like an account url) from the keychain:
```
    let results = ItemSearchOptions::new()
        .class(ItemClass::generic_password())
        .label(&args.label)
        .load_refs(true)
        .load_attributes(true)
        .load_data(true)
        .search()?;

    let result = results
        .first()
        .ok_or(format_err!("No results for that keychain label."))?;
    let mut dict = result
        .simplify_dict() // I added this because the raw keychain result is pretty hard to work with.
        .ok_or(format_err!("Couldn't interpret keychain item."))?;
    let acct: String = dict
        .remove("acct")
        .ok_or(format_err!("No account info in the keychain item."))?;
    let pass: String = dict
        .remove("v_Data")
        .ok_or(format_err!("No password info in the keychain item."))?;

    println!("Got account: {}, pass: {}", acct, pass);
```

Being able to return both account URL and password by searching for a label makes writing CLI utilities much more convenient. A user can store their api key for some service in the keychain by creating a generic password or internet password, and the CLI utility can look up a supplied label, and get back all the data (service URL) and credentials it needs to access the service.